### PR TITLE
cjs version

### DIFF
--- a/examples/random-colors.js
+++ b/examples/random-colors.js
@@ -12,8 +12,8 @@ $ node examples/random-colors.js
 #bba079
 */
 
-import phiColor from "../index.js";
-import chroma from "chroma-js";
+const phiColor = require("../index.js");
+const chroma = require("chroma-js");
 
 const origin = chroma("steelblue").hcl();
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import chroma from "chroma-js";
+const chroma = require("chroma-js");
 
 const phi = (d) => {
   let x = 2;
@@ -65,4 +65,4 @@ const phiColor = (origin, magnitude, n) => {
   return colors;
 };
 
-export default phiColor;
+module.exports = phiColor;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "author": "damon@stamen.com",
   "license": "ISC",
-  "type": "module",
   "bugs": {
     "url": "https://github.com/stamen/phi-color/issues"
   },


### PR DESCRIPTION
Because of the way that we're running the current scripts, I needed a CJS version instead of an ES version, so here's a quick and dirty CJS version. Ideally we would have this library generate both versions with rollup or webpack, so this is just a quick stopgap to be aware of this issue.

Also I don't currently have push access to this repo so I had to fork it.