### PR TITLE
Use Color Strings instead of chroma objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Generate random colors within a given sphere in the HCL color space using the Go
 phiColor(origin, magitude, n)
 ```
 ### Parameters
-- `origin`: The `chroma.Color` that should be used as the perceptual center for the color palette
+- `origin`: The color string that should be used as the perceptual center for the color palette
 - `magnitude`: The magnitude as a proportion of each dimension of HCL that colors should be created within. A `magnitude` of 0 will return `n` colors identical to the `origin`, while a magnitudes above 1 will create entirely disparate colors
 - `n`: The number of colors to generate
 
 ### Returns
-- `Array` of `chroma.Color` objects of length `n`
+- `Array` of color strings of length `n`
 
 ## examples
 - Return 10 colors as line-delimited hex from a `steelblue` origin: https://github.com/stamen/phi-color/blob/main/examples/random-colors.js

--- a/examples/random-colors.js
+++ b/examples/random-colors.js
@@ -13,13 +13,10 @@ $ node examples/random-colors.js
 */
 
 import phiColor from "../index.js";
-import chroma from "chroma-js";
 
-const origin = chroma("steelblue").hcl();
+const origin = "steelblue";
 
-const colors = phiColor(origin, 0.5, 25).map((c) => {
-  return c.hex();
-});
+const colors = phiColor(origin, 0.5, 25);
 
 // console.log(colors.join("\n"));
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const generatePhiCircle = function* (options) {
 /**
  * Generate `n` colors around an origin within a magnitude of
  * `m` in HCL color space
- * @param {chroma.Color} origin - The central color to generate from
+ * @param {string} origin - The central color to generate from
  * @param {float} magnitude - magnitude to generate colors within
  * @param {float} n - number of colors to generate
  */
@@ -50,7 +50,7 @@ const phiColor = (origin, magnitude, n) => {
     return s * magnitude;
   });
   for (const c of generatePhiCircle()) {
-    const color = origin.map((o, i) => {
+    const color = chroma(origin).hcl().map((o, i) => {
       return (c[i] - 0.5) * scaled[i] + o;
     });
     if (
@@ -59,7 +59,7 @@ const phiColor = (origin, magnitude, n) => {
       color[2] > 0 &&
       color[2] < domain[2]
     ) {
-      colors.push(chroma.hcl(color));
+      colors.push(chroma.hcl(color).hex());
       if (colors.length == n) break;
     }
   }


### PR DESCRIPTION
By allowing usage of this library to simply pass in color strings, users no longer have to go through the extra step of converting their color strings into a chroma object.